### PR TITLE
Updates caching strategy

### DIFF
--- a/src/test/java/data/CacheManagerTest.java
+++ b/src/test/java/data/CacheManagerTest.java
@@ -28,10 +28,12 @@ public class CacheManagerTest implements Cacheable {
             else
                 System.out.println(i + ": No 1");
              */
+
+            if(i == 20) cache.get(1); // updating the access
         }
 
-        Assert.assertEquals(null, cache.get(1));
-        Assert.assertNotNull(cache.get(2));
+        Assert.assertNotNull(cache.get(1));     // 1 was accessed, cache was reordered
+        Assert.assertNull(cache.get(2));        // 2 should've been removed instead
         Assert.assertNotNull(cache.get(20));
     }
 }


### PR DESCRIPTION
Now accounting for the last access to take advantage of the temporal locality property of caching, albeit in a very, **very** simple way.

It simply makes a weighted average of the values used in the cache. The weight given to the last access property seems to be fair enough to just push the value a little up the queue and avoid it being polled so soon.

Reordering the queue is costly since it essencially has to remove an object (which is an O(n) bounded operation) and then add it again (which is O(log n)). I don't think there's alternative to this in Java.
